### PR TITLE
Update dependencies for Compose Material 3

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,12 +47,12 @@ android {
 
 dependencies {
 
-    implementation 'androidx.core:core-ktx:1.7.0'
+    implementation 'androidx.core:core-ktx:1.8.0'
     implementation "androidx.compose.ui:ui:$compose_version"
-    implementation 'androidx.compose.material3:material3:1.0.0-alpha01'
+    implementation 'androidx.compose.material3:material3:1.0.0-alpha15'
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
-    implementation 'androidx.activity:activity-compose:1.3.1'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.1'
+    implementation 'androidx.activity:activity-compose:1.5.1'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
     ext {
-        compose_version = '1.1.0-beta01'
+        compose_version = '1.2.0-alpha08'
     }
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id 'com.android.application' version '7.2.2' apply false
     id 'com.android.library' version '7.2.2' apply false
-    id 'org.jetbrains.kotlin.android' version '1.5.31' apply false
+    id 'org.jetbrains.kotlin.android' version '1.6.20' apply false
 }
 
 task clean(type: Delete) {


### PR DESCRIPTION
This pull request updates the dependencies necessary to use the latest Compose Material 3 Alpha (1.0.0-alpha15), which does not yet support the latest versions of all relevant libraries / plugins. Other dependencies are also updated where appropriate. 